### PR TITLE
fix: allow days_remaining update on submitted Warranty List

### DIFF
--- a/avientek/avientek/doctype/warranty_list/warranty_list.json
+++ b/avientek/avientek/doctype/warranty_list/warranty_list.json
@@ -184,7 +184,8 @@
    "fieldtype": "Int",
    "label": "Days Remaining",
    "read_only": 1,
-   "bold": 1
+   "bold": 1,
+   "allow_on_submit": 1
   },
   {
    "fieldname": "section_notes",

--- a/avientek/avientek/doctype/warranty_list/warranty_list.py
+++ b/avientek/avientek/doctype/warranty_list/warranty_list.py
@@ -18,7 +18,8 @@ class WarrantyList(frappe.model.document.Document):
 			self.status = "Under Warranty"
 
 	def on_update_after_submit(self):
-		self.update_days_remaining()
+		if self.warranty_end_date:
+			self.db_set("days_remaining", date_diff(self.warranty_end_date, today()))
 
 	def on_cancel(self):
 		self.db_set("status", "Cancelled")


### PR DESCRIPTION
## Summary
- Add `allow_on_submit` to `days_remaining` field in Warranty List
- Use `db_set()` in `on_update_after_submit` to avoid "Cannot Update After Submit" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)